### PR TITLE
workflows: stop get_inputs job running on both PR and PRT triggers

### DIFF
--- a/.github/workflows/ucm-imx93.yml
+++ b/.github/workflows/ucm-imx93.yml
@@ -83,6 +83,11 @@ jobs:
   get_inputs:
     name: Get inputs
     runs-on: ubuntu-latest
+    # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
+    # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.
+    # This condition will prevent the workflow from running twice for the same pull request while
+    # still allowing it to run for all other event types.
+    if: (github.event.pull_request.head.repo.full_name == github.repository) == (github.event_name == 'pull_request')
     outputs:
       test_matrix: ${{ inputs.test_matrix || env.test_matrix }} 
     steps:


### PR DESCRIPTION
This stops an issue in the yocto-scripts workflow logic caused by get_inputs running twice on commits

Changelog-entry: workflows: stop get_inputs job running on both PR and PRT triggers