### PR TITLE
Compress the kernel and balena-bootloader

### DIFF
--- a/layers/meta-balena-imx9/conf/layer.conf
+++ b/layers/meta-balena-imx9/conf/layer.conf
@@ -22,3 +22,5 @@ HOSTTOOLS:remove = " git-lfs "
 HOSTTOOLS:remove = " bison "
 
 MACHINE_FEATURES:remove = "optee"
+
+KERNEL_IMAGETYPE:iot-link = "Image.gz"

--- a/layers/meta-balena-imx9/recipes-bsp/u-boot-scr/u-boot-script/compulab-mx93/boot.script
+++ b/layers/meta-balena-imx9/recipes-bsp/u-boot-scr/u-boot-script/compulab-mx93/boot.script
@@ -3,9 +3,11 @@ echo "balenaOS boot script"
 usb start
 if fatload usb 0:1 ${initrd_addr} balena-image-flasher; then setenv bootdev usb; setenv bootargs root=LABEL=flash-rootA flasher; else setenv bootdev mmc; fi
 
+setenv image_zip_addr ${initrd_addr}
 setenv image_load_addr 0x98000000
 
-load  ${bootdev} 0:1 ${image_load_addr} Image
+load  ${bootdev} 0:1 ${image_zip_addr} Image.gz
 load  ${bootdev} 0:2 ${fdt_addr_r} boot/${fdtfile}
+unzip ${image_zip_addr} ${image_load_addr}
 setenv bootargs ${bootargs} console=${console} rootwait balena_stage2
 booti ${image_load_addr} - ${fdt_addr_r}

--- a/layers/meta-balena-imx9/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-imx9/recipes-core/images/balena-image.inc
@@ -26,6 +26,8 @@ IMAGE_ROOTFS_SIZE = "983040"
 # balena-bootloader support for iot-link
 BALENA_BOOT_PARTITION_FILES:append:iot-link = " boot.scr:/boot.scr "
 RDEPENDS:${PN}:iot-link += " u-boot-script "
+IMAGE_ROOTFS_SIZE:iot-link = "655360"
+BALENA_BOOT_SIZE:iot-link="81920"
 
 BALENA_BOOT_PARTITION_FILES:append:iot-link = " \
     balena-bootloader/${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin:/${KERNEL_IMAGETYPE} \


### PR DESCRIPTION
This brings their sizes down to half.

Changelog-entry: Compress the kernel and balena-bootloader