### PR TITLE
linux-balena-bootloader: Prevent depmod to be executed for this recip…

### DIFF
--- a/.github/workflows/iot-link.yml
+++ b/.github/workflows/iot-link.yml
@@ -95,7 +95,7 @@ jobs:
 
   yocto:
     name: Yocto
-    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@22b8b77a848df921c3b96a1bf689f91ee453ccb4
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@23eb6005eba2a46be19a28a8e94d382257966b52
     needs: get_inputs
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.

--- a/.github/workflows/ucm-imx93.yml
+++ b/.github/workflows/ucm-imx93.yml
@@ -95,7 +95,7 @@ jobs:
 
   yocto:
     name: Yocto
-    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@22b8b77a848df921c3b96a1bf689f91ee453ccb4
+    uses: balena-os/balena-yocto-scripts/.github/workflows/yocto-build-deploy.yml@23eb6005eba2a46be19a28a8e94d382257966b52
     needs: get_inputs
     # Prevent duplicate workflow executions for pull_request (PR) and pull_request_target (PRT) events.
     # Both PR and PRT will be triggered for the same pull request, whether it is internal or from a fork.

--- a/layers/meta-balena-imx9/recipes-kernel/linux/linux-balena-bootloader_%.bbappend
+++ b/layers/meta-balena-imx9/recipes-kernel/linux/linux-balena-bootloader_%.bbappend
@@ -12,8 +12,8 @@ BALENA_DEFCONFIG_NAME = "${KERNEL_CONFIG}"
 do_install:append() {
     # Module support is needed as a dependency for kexec image authentication
     # specifically CONFIG_SYSTEM_DATA_VERIFICATION
-    # But we remove modules here
-    rm -rf ${D}/etc ${D}${nonarch_base_libdir} ${D}${exec_prefix}
+    # But we remove modules here and everything else from /usr
+    rm -rf ${D}/usr
 }
 
 do_deploy:append () {
@@ -31,3 +31,6 @@ INITRAMFS_IMAGE = "balena-image-bootloader-initramfs"
 KERNEL_PACKAGE_NAME = "balena-bootloader"
 
 PROVIDES = "virtual/balena-bootloader"
+
+# remove this task to prevent the creation of the metadata that triggers rootfs.py to run depmod for the linux-balena-bootloader
+deltask do_packagedata


### PR DESCRIPTION
…e during rootfs creation

If depmod runs for balena bootloader it will create duplicate modules.* files in /lib/modules/<kernel abiversion> and it will mess up loading the modules at runtime.

Changelog-entry: Prevent depmod to be executed for balena bootloader during rootfs creation