### PR TITLE
linux-compulab: Always force recompile

### DIFF
--- a/layers/meta-balena-imx9/recipes-kernel/linux/linux-compulab_%.bbappend
+++ b/layers/meta-balena-imx9/recipes-kernel/linux/linux-compulab_%.bbappend
@@ -33,3 +33,6 @@ BALENA_CONFIGS[noar1335] = " \
 	CONFIG_MXC_CAMERA_AR1335_AF=n \
 	CONFIG_MXC_CAMERA_AR1335_MCU=n \
 "
+
+# always force kernel recompile to avoid potential broken sstate
+do_compile[nostamp] = "1"


### PR DESCRIPTION
We do this to avoid stale broken sstate

Changelog-entry: Always force kernel recompile to avoid stale broken sstate