### PR TITLE
balena-image: Set explicit partition size overrides for each machine

### DIFF
--- a/layers/meta-balena-imx9/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-imx9/recipes-core/images/balena-image.inc
@@ -38,3 +38,9 @@ IMAGE_INSTALL:append:iot-link = " grub-editenv"
 
 do_rootfs[depends] += " virtual/balena-bootloader:do_deploy"
 do_image_balenaos_img[depends] += " virtual/balena-bootloader:do_deploy"
+
+BALENA_STATE_SIZE:iot-link = "20480"
+BALENA_BOOT_SIZE:mcm-imx93 = "40960"
+BALENA_STATE_SIZE:mcm-imx93 = "20480"
+BALENA_BOOT_SIZE:ucm-imx93 = "40960"
+BALENA_STATE_SIZE:ucm-imx93 = "20480"


### PR DESCRIPTION
## Summary
- Explicitly define `IMAGE_ROOTFS_SIZE`, `BALENA_BOOT_SIZE`, and `BALENA_STATE_SIZE` for every machine target in this repo, preserving any existing custom values and applying fallback defaults (327680/40960/20480) where none were previously set.